### PR TITLE
Adding release management responsibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/.DS_Store
+_site/

--- a/_includes/navigation-fr.html
+++ b/_includes/navigation-fr.html
@@ -13,6 +13,7 @@
 <ul>
 <li><a href="{{ site.baseurl }}{% link _pages/fr/principes.md %}">Principes sur la façon dont les équipes produits créent des services</a></li>
 <li><a href="{{ site.baseurl }}{% link _pages/en/responsibilities.md %}">Product team member responsibilities (en traduction)</a></li>
+<li><a href="{{ site.baseurl }}{% link _pages/fr/responsabilités-de-la-gestion-des-versions.md %}">Responsabilités de la gestion des versions</a></li>
 <li><a href="https://docs.google.com/document/d/1t3YX3zBhnLcWYNCJ-hkYvseEWE20n9FJmq6563LwQ5o/edit">Phase patterns (en traduction)</a></li>
 <li><a href="https://docs.google.com/document/d/1z_UBsleGrzh720ucN5zf2vb3LFGvj29mHGodx7_1pf4/edit#bookmark=kix.grv964mu7vr0">J&#39;ai besoin d&#39;aide... Que devrais-je faire ? Pour les membres de l&#39;équipe produit</a></li>
 </ul>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,6 +3,7 @@
 <ul>
 	<li><a href="{{ site.baseurl }}{% link _pages/en/principles.md %}">Principles for how product teams build services (draft)</a></li>
 	<li><a href="{{ site.baseurl }}{% link _pages/en/responsibilities.md %}">Product team member responsibilities</a></li>
+	<li><a href="{{ site.baseurl }}{% link _pages/en/release-management-responsibilities.md %}">Release management responsibilities</a></li>
 	<li><a href="https://docs.google.com/document/d/1t3YX3zBhnLcWYNCJ-hkYvseEWE20n9FJmq6563LwQ5o/edit">Phase patterns</a></li>
 	<li><a href="https://docs.google.com/document/d/1z_UBsleGrzh720ucN5zf2vb3LFGvj29mHGodx7_1pf4/edit#heading=h.sjqaiear3f3t">I need help…what should I do? (For product team members)</a></li>
 </ul>

--- a/_pages/en/release-management-responsibilities.md
+++ b/_pages/en/release-management-responsibilities.md
@@ -1,0 +1,96 @@
+---
+layout: homepage
+title:  "Release management responsibilities"
+lang: en
+permalink: "/release-management-responsibilities/"
+trans_url: "/responsabilités-de-la-gestion-des-versions/"
+---
+
+## Release management responsibilities
+
+**Purpose of this document:** An understanding of what responsibilities belong to what role across the product team and business units when dealing with production releases
+
+**If there are multiple team members from a community on a team, they share the responsibilities for their discipline.** For example, if there are multiple developers on a product, they divide up the responsibilities amongst themselves.
+
+**Others can (and should) support other team’s responsibilities.** This document describes who’s ultimately accountable. It doesn’t limit who can be involved. Many responsibilities touch many members of a product team. 
+
+- <a href="#section-1">What is release management?</a>
+- <a href="#section-2">Product/Delivery manager responsibilities</a>
+- <a href="#section-3">Developer responsibilities</a>
+- <a href="#section-4">Scenarios/Walkthroughs</a>
+
+### What is release management? {#section-1}
+
+Release management describes all the processes and artifacts related to getting code from an idea to running it in production, while causing as little disruption as possible.
+
+### Product/Delivery manager responsibilities {#section-2}
+
+*   Supports the development team in implementing the release engineering playbook (_document in progress_)
+*   Works with the development team in defining a release checklist
+*   Accounts for ATO (Authorized to Operate), SA&A (Security assessment and authorization) changes
+*   Agrees upon a <a href="https://semver.org/">Semantic Versioning</a> scheme for software or components that communicates impact of change
+*   Decides how to publish release notes or notify upcoming changes
+*   Ensures impact of changes has been thoroughly analyzed (business readiness and product dependencies) 
+*   Works with business units and outreach teams in communicating changes to all layers (users, support, stakeholders)
+*   Establishes an agile release train process if releasing a single component cannot be done independently
+
+### Developer responsibilities {#section-3}
+
+*   Ensures the following release engineering best practices are implemented:
+    * Testing, staging and production environments and their deployment pipelines
+    * Standardized pull request review
+    * Application versioning scheme
+    * Manifest of compatible system components (i.e. create system versions)
+    * Release notes automation
+    * Release checklist
+    * Release change audit
+    * Ease rollback
+    * Blue/green deployment
+    * Canary release
+
+*   Ensures each release candidate is properly tested (manually or automatically).  Testing should cover: unit tests, integration tests and performance tests.
+* Ensures each release candidate has gone through a vulnerability scanning
+* Defines a play-by-play for hotfix/urgent fixes
+* Finalizes release verification through canary or blue/green approach
+* Enables release in production for all customers
+* Validates production logs and metrics
+* Notifies PM/DM that release is completed
+
+
+### Scenarios/Walkthroughs {#section-4}
+
+_All the changes involved in those scenarios could be application code, infrastructure code, configuration or some environment changes._
+
+#### An MVP is being built and we are planning for the first launch
+
+1. Developers work with the product manager, delivery manager and the service reliability advisors in implementing the must have release engineering practices:
+    * Testing, staging and production environments and their deployment pipelines
+    * Standardized pull request review
+    * Application versioning scheme
+    * Manifest of compatible system components (i.e. create system versions)
+    * Release notes automation
+    * Release checklist
+    * Release change audit
+1. PM gives the green light to prepare for a production release
+1. Developer kicks off the release
+
+#### A new feature is completed and ready to be released for an existing live product
+
+1. The Product Manager with the help of the Tech Lead is responsible for assessing the impact of the new app version to be delivered.
+1. Developer defines/reviews the play-by-play for hotfix/urgent fixes
+1. Developer go through the release checklist with the DM
+1. Developer validates the new release via a canary release or blue/green deployment and PM provides sign off
+1. Developer enables the new release for all customers
+1. Developer do final verification in production
+1. PM/DM write and sends release note to all stakeholders and customers
+
+#### Product features spanning multiple services ready to be released (interdependence) 
+1. The Product Manager with the help of the Product Tech Lead is responsible for assessing the impact of the new app version to be delivered
+    * Ideally every component release should be independent and not impact other components. Tech lead should work on ensuring that proper techniques are used to make it so: backward compatibility, new API versions, and feature flagging
+    * If independent release is not possible, an Agile Release Train process needs to be established
+1. Agile Release Train process
+    * A fix schedule is defined (every sprint)
+    * System demo: The System Demo provides a mechanism for evaluating the working system, which is an integrated increment from all the teams
+    * Synchronization is applied – All teams on the train are synchronized to the same sprint length
+    * A dedicated DM is assigned and dedicated to the train
+    * DM ensure silos are broken and communication heightened 

--- a/_pages/fr/accueil.html
+++ b/_pages/fr/accueil.html
@@ -7,4 +7,3 @@ trans_url: "/home/"
 ---
 
 {% include navigation-fr.html %}
-Test

--- a/_pages/fr/responsabilités-de-la-gestion-des-versions.md
+++ b/_pages/fr/responsabilités-de-la-gestion-des-versions.md
@@ -1,0 +1,95 @@
+---
+layout: homepage
+title:  "Responsabilités de la gestion des versions"
+lang: fr
+permalink: "/responsabilités-de-la-gestion-des-versions/"
+trans_url: "/release-management-responsibilities/"
+---
+
+## Responsabilités de la gestion des versions
+
+**Objectif du présent document:** Comprendre quelles sont les responsabilités et le rôle de l'équipe produit et des unités commerciales dans le traitement des déploiements de versions applicatifs en production.
+
+**Si une équipe compte plusieurs membres d'une même communauté, ils partagent les responsabilités de leur discipline.** Par exemple, s'il y a plusieurs développeurs sur un produit, ils se répartissent les responsabilités entre eux.
+
+**D'autres peuvent (et devraient) soutenir les responsabilités d'autres équipes.** Ce document décrit qui est responsable en dernier ressort. Il ne limite pas les personnes qui peuvent être impliquées. De nombreuses responsabilités touchent de nombreux membres d'une équipe produit.
+
+- <a href="#section-1">Qu'est-ce que la gestion des version?</a>
+- <a href="#section-2">Responsabilités du chef de produits/prestation des services</a>
+- <a href="#section-3">Responsabilités des développeurs</a>
+- <a href="#section-4">Scénarios/Projets</a>
+
+### Qu'est-ce que la gestion des version? {#section-1}
+
+La gestion des versions décrit tous les processus et artefacts liés au passage du code d'une idée à son exécution en production, tout en causant le moins de perturbations possible.
+
+### Responsabilités du chef de produits/prestation des services {#section-2}
+
+* Aide l'équipe de développement dans la mise en œuvre du guide d'ingénierie des versions (_document en cours_)
+* Travaille avec l'équipe de développement pour définir une liste de contrôle des versions
+* Fais le suivi des changements du ATO (autorisé à opérer) et le SA&A (Évaluation et autorisation de sécurité)
+* Convient d'une <a href="https://semver.org/lang/fr/">gestion sémantique de version</a>
+* Décide de la manière de publier les notes de publication ou de notifier les changements à venir
+* S'assure que l'impact des changements a été analysé en profondeur (interdépendances des produits) 
+* Travaille avec les unités commerciales et les équipes de sensibilisation pour communiquer les changements à tous les niveaux (utilisateurs, soutien, parties prenantes)
+* Établit un processus agile de train de libération si la libération d'un seul composant ne peut être effectuée de manière indépendante
+
+### Responsabilités des développeurs {#section-3}
+
+*   Veille à ce que les meilleures pratiques d'ingénierie de publications suivantes soient mises en œuvre :
+    * Un environnements d'essai, d'intégration et de production et leurs système de déploiement automatique
+    * Examen standardisé des demandes de tirages
+    * Schéma de versionnement des applications
+    * Manifeste des composants de système compatibles (c'est-à-dire créer des versions de système)
+    * Automatisation des notes de mise à jour
+    * Liste de contrôle de version
+    * Audit de changement de version
+    * Faciliter le retour en arrière
+    * Déploiement bleu/vert
+    * Activer la nouvelle version en étape
+
+* S'assure que chaque candidat applicatif est correctement testé (manuellement ou automatiquement).  Les tests doivent couvrir: les tests unitaires, les tests d'intégration et les tests de performance.
+* S'assurer que chaque version candidate a été soumise à une analyse de vulnérabilité
+* Définit une procédure de correction des problèmes urgents
+* Finalise la vérification de la version par l'approche canari ou bleu/vert
+* Active la mise en production pour tous les clients
+* Valide les registres et les métriques de production
+* Notifie le PM/DM que la publication de la version est terminée
+
+### Scénarios/Projets {#section-4}
+
+Tous les changements impliqués dans ces scénarios pourraient être le code de l'application, le code de l'infrastructure, la configuration ou certains changements d'environnement.
+
+#### Un MVP est en cours de construction et nous prévoyons le premier lancement
+
+1. Les développeurs travaillent avec le responsable produit, le responsable de la livraison et les conseillers en fiabilité du service pour mettre en œuvre les requis de bases pour l'ingénierie de versionnement :
+    * Environnements de test, d'intégration et de production et leurs systèmes de déploiement
+    * Examen standardisé des demandes de tirage
+    * Schéma de versionnement de l'application
+    * Manifeste des composants de système compatibles (c'est-à-dire créer des versions de système)
+    * Automatisation des notes de mise à jour
+    * Liste de contrôle de la libération
+    * Audit de changement de version
+1. Le chef de produit donnent le feu vert pour préparer le déploiement de la version
+1. Le développeur déploi la nouvelle version
+
+#### Une nouvelle fonctionnalité est achevée et prête à être diffusée pour un produit existant
+
+1. Le chef de produit, avec l'aide du responsable technique, est chargé d'évaluer l'impact de la nouvelle version de l'application à livrer.
+1. Le développeur définit/révise le mode d'emploi pour les correctifs urgents
+1. Le développeur passe en revue la liste de contrôle des versions avec le DM
+1. Le développeur valide la nouvelle version via une version canari ou un déploiement bleu/vert et le chef de produit donne son accord
+1. Le développeur active la nouvelle version pour tous les clients
+1. Le développeur effectue la vérification finale en production
+1. Le PM/DM rédige et envoie une note de mise à jour à toutes les parties prenantes et aux clients
+
+#### Caractéristiques du produit couvrant plusieurs services prêts à être publiés (interdépendance) 
+1. Le chef de produit, avec l'aide du responsable technique du produit, est chargé d'évaluer l'impact de la nouvelle version de l'application à livrer
+    * Idéalement, chaque sortie de composant devrait être indépendante et ne pas avoir d'impact sur les autres composants. Le responsable technique doit s'assurer que les techniques appropriées sont utilisées pour qu'il en soit ainsi : rétrocompatibilité, nouvelles versions d'API et marquage des caractéristiques
+    * Si une libération indépendante n'est pas possible, un processus de coordination de versionnement agile doit être mis en place
+1. Processus "Agile Release Train"
+    * Un calendrier fixe est défini (chaque sprint)
+    * Démonstration du système : La démo du système fournit un mécanisme d'évaluation du système de travail, qui est un incrément intégré de toutes les équipes
+    * La synchronisation est appliquée - Toutes les équipes dans le train sont synchronisées sur la même durée de sprint
+    * Un DM est affecté et dédié au train
+    * Le DM veille à ce que les silos soient brisés et à ce que la communication soit renforcée 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -68,11 +68,6 @@ h2 {
     margin: 1.4em 0 0 0;
 }
 
-h4 {
-    font-size: 1em;
-    text-transform: uppercase;
-}
-
 .page-title {
     margin-top: .727272727em; /* 16/22 */
 }


### PR DESCRIPTION
This PR completes the publication of [Release management - responsibility for communities](https://docs.google.com/document/d/1yUkPVOda-aHRGqCpdPyGq0SuWCqz6cnh-ziswrn8kQQ/edit#heading=h.pfe3kmdxel6k) that was reviewed by all CDS. @mcman12 let me know if the french version make sense. 


![image](https://user-images.githubusercontent.com/70960477/99147843-1667b080-2652-11eb-86b7-6cc0f3398092.png)

![image](https://user-images.githubusercontent.com/70960477/99147863-34cdac00-2652-11eb-96f0-865c4ebf4489.png)

**French**

![image](https://user-images.githubusercontent.com/70960477/99147850-267f9000-2652-11eb-84ec-5e0eaf495093.png)

![image](https://user-images.githubusercontent.com/70960477/99147855-2e3f3480-2652-11eb-9f57-396990a94bfe.png)
